### PR TITLE
Allow DyeableItem and IotaHolderItem to be used separately

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,11 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+
+	mappings loom.layered() {
+		mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+		mappings file("mappings/dyeableitemfix.tiny")
+	}
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.

--- a/mappings/dyeableitemfix.tiny
+++ b/mappings/dyeableitemfix.tiny
@@ -1,0 +1,3 @@
+tiny	2	0	intermediary	named
+c	net/minecraft/class_1768	net/minecraft/item/DyeableItem
+	m	(Lnet/minecraft/item/ItemStack;)I	method_7800	getDyeColor

--- a/src/main/java/net/fabricmc/example/ItemDyeableSpellbook.java
+++ b/src/main/java/net/fabricmc/example/ItemDyeableSpellbook.java
@@ -15,4 +15,9 @@ public class ItemDyeableSpellbook extends ItemSpellbook
     public int getColor(ItemStack stack){
         return 0;
     }
+
+    @Override
+    public int getDyeColor(ItemStack stack) {
+        return 0;
+    }
 }


### PR DESCRIPTION
The addition of a custom mapping removes the UB wherein the Java Compiler (and tiny-remapper) observe via the JLS that `DyeableItem#getColor` and `IotaHolderItem#getColor` are `Override`-equivalent, but that constraint is not held at runtime (resulting in a link error and crash).